### PR TITLE
Add linux version and hack python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@
 - ### Mac
 
   - 下载并安装即可
+
+- ### Linux
+
+  ```shell
+  sudo dpkg -i typora_1.6.6_amd64.deb
+  python hack_typora_linux.py
+  ```

--- a/hack_typora_linux.py
+++ b/hack_typora_linux.py
@@ -1,0 +1,44 @@
+# this script is to crack the typora software on Ubuntu/Linux
+from pathlib import Path
+import os
+import re
+
+licence_dir = '/usr/share/typora/resources/page-dist/static/js'
+licence_dir = Path(licence_dir)
+
+# check if the directory exists
+if not licence_dir.exists():
+    raise Exception('cannot find the directory')
+
+# change the permission
+print(f"Doing sudo chmod 777 -R for {str(licence_dir)}, might need to enter password")
+os.system('sudo chmod 777 -R ' + str(licence_dir))
+
+prefix = 'LicenseIndex'
+
+licence_dir = Path(licence_dir).iterdir()
+
+licence_file = None
+for file in licence_dir:
+    if file.name.startswith(prefix):
+        licence_file = file
+
+print(f"Found the licence file: {licence_file.name}")
+if licence_file is None:
+    raise Exception('cannot find licence file')
+
+print("Overwriting the licence file...")
+# read file content
+with open(licence_file, 'r') as f:
+    content = f.read()
+
+# replace the pattern
+target = 'e.hasActivated="true"==e.hasActivated'
+replacement = 'e.hasActivated="true"=="true"'
+content = re.sub(target, replacement, content)
+
+# write the content to original file
+with open(licence_file, 'w') as f:
+    f.write(content)
+
+print("Hack done!")


### PR DESCRIPTION
The linux deb file is downloaded from official history release, and using the hack python script can easily modify the license. Tested on Ubuntu 20.04